### PR TITLE
Setup Github Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.ipython
+.local
+.jupyter
+.git
+__pycache__

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -59,13 +59,16 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -t $ECR_REPOSITORY:$IMAGE_TAG .
+        docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         
     - name: Download task definition
       run: |
-        aws ecs describe-task-definition --task-definition my-task-definition-family --query taskDefinition > task-definition.json
+        aws ecs describe-task-definition --task-definition coviz --query taskDefinition > task-definition.json
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,0 +1,84 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS, when a release is created
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Create an ECR repository to store your images.
+#    For example: `aws ecr create-repository --repository-name my-ecr-repo --region us-east-2`.
+#    Replace the value of `ECR_REPOSITORY` in the workflow below with your repository's name.
+#    Replace the value of `aws-region` in the workflow below with your repository's region.
+#
+# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
+#    For example, follow the Getting Started guide on the ECS console:
+#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
+#    Replace the values for `service` and `cluster` in the workflow below with your service and cluster names.
+#
+# 3. Store your ECS task definition as a JSON file in your repository.
+#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
+#    Replace the value of `task-definition` in the workflow below with your JSON file's name.
+#    Replace the value of `container-name` in the workflow below with the name of the container
+#    in the `containerDefinitions` section of the task definition.
+#
+# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
+#    and best practices on handling the access key credentials.
+
+on:
+  release:
+    types: [created]
+
+name: Deploy to Amazon ECS
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.COVIZ_REGISTRY_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.COVIZ_REGISTRY_SECRET_KEY }}
+        aws-region: us-east-1
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: wmkt-coviz
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        
+    - name: Download task definition
+      run: |
+        aws ecs describe-task-definition --task-definition my-task-definition-family --query taskDefinition > task-definition.json
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: coviz
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: coviz-ecs-service
+        cluster: default
+        wait-for-service-stability: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.local
+.jupyter
+.ipython
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM jupyter/base-notebook
+
+LABEL version=".1"
+LABEL description="Jupyter notebook with support for interactive widgets"
+
+# Set the working directory
+WORKDIR /home/jovyan/
+COPY . /home/jovyan/
+
+RUN conda install --quiet --yes -c conda-forge\
+    'numpy' \
+    'scipy' \
+    'pandas' \
+    'matplotlib' \
+    'jupyter' \
+    'bqplot' \
+    'voila' && \
+    jupyter serverextension enable voila --sys-prefix && \
+    rm -rf work
+
+# Expose default HTTP port
+EXPOSE 8866
+
+# we have to use the root user so that we can use task storage volume on ECS
+# See: https://github.com/aws/containers-roadmap/issues/938
+USER root
+
+# start voila dahboard
+CMD ["voila", "coviz/notebooks/Dashboard.ipynb", "--VoilaConfiguration.theme='dark'", "--MappingKernelManager.cull_interval=60", "--MappingKernelManager.cull_idle_timeout=300", "--no-browser"]
+
+# EXPOSE 8888
+# start jupyter notebook
+# CMD jupyter notebook --no-browser --port 8888 --ip=0.0.0.0 --NotebookApp.token='' --NotebookApp.disable_check_xsrf=True --allow-root
+
+# docker command
+# docker run -p 8866:8866 -v "$PWD":/home/jovyan qr:v2

--- a/jupyter_config.json
+++ b/jupyter_config.json
@@ -1,4 +1,7 @@
 {
+  "Session": {
+    "session": "eb4dcf6e-f1f5-422e-b7b0-cdcf10355ace"
+  },
   "VoilaConfiguration": {
     "theme": "dark"
   }


### PR DESCRIPTION
As currently configured, the way this will work is that any time we cut a new release via the Github "releases" tab, this job will be automatically triggered which will build a new version of the docker image and then push it to our ECR registry. It will then generate a new task definition and update the Fargate service to use that new definition (thus making the most recent changes go live).

This task will likely evolve as we introduce both staging and production environments to our workflow but I'm eager to test this as is for now so that we can validate that the basic concept with work.